### PR TITLE
Functionality to treat pupil time series as packets

### DIFF
--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -132,8 +132,6 @@ switch packetType
             case {'V1' 'LGN' 'V2V3'}
                 HRF                         = load(fullfile(hrfDir,[roiType '.mat']));
         end
-    case 'pupil'
-        
 end
 
 
@@ -198,6 +196,164 @@ for i = 1:length(runDirs)
         % save stimulus values
         stimulus{i}.values(j,:)     = thisStim;
     end
+end
+
+%% Response packet loading pupil
+switch packetType
+    case 'pupil'
+        params.LiveTrackSamplingRate = 60; % Hz
+        params.ResamplingFineFreq = 1000; % 1 msec
+        params.BlinkWindowSample = -50:50; % Samples surrounding the blink event
+        params.NTRsExpected = runDur/800;
+        params.TRDurSecs = 0.8;
+        
+        for i = 1:length(runDirs)
+            response{i}.timebase = stimulus{i}.timebase;
+            params.TimeVectorFine = response{i}.timebase;
+            
+            switch sessionDate
+                case {'053116' '060116' '060216'}
+                    acquisitionFreq = 60;
+                otherwise
+                    acquisitionFreq = 30;
+            end
+            
+            %
+            %%% EYE TRACKING DATA %%%
+            % Load the eye tracking data
+            Data_LiveTrack = load(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}));
+            
+            % Find cases in which the TTL pulse signal was split over the two
+            % samples, and remove the second sample.
+            Data_LiveTrack_TTLPulses_raw = [Data_LiveTrack.params.Report.Digital_IO1];
+            tmpIdx = strfind(Data_LiveTrack_TTLPulses_raw, [1 1]);
+            Data_LiveTrack_TTLPulses_raw(tmpIdx) = 0;
+            
+            Data_LiveTrack_TTLPulses = [];
+            Data_LiveTrack_PupilDiameter = [];
+            Data_LiveTrack_IsTracked = [];
+            % We reconstruct the data set collected at 30/60 Hz.
+            for rr = 1:length(Data_LiveTrack.params.Report)
+                % Depending on how we set up the acquisiton frequency, we have to
+                % do different things to extract the data
+                switch acquisitionFreq
+                    case 60
+                        Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr) 0];
+                        
+                        % We use the pupil width as the index of pupil diameter
+                        Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).PupilWidth_Ch01 ...
+                            Data_LiveTrack.params.Report(rr).PupilWidth_Ch02];
+                        
+                        % Special case
+                        if strcmp(dateID, '060616') && strcmp(subjectID, 'HERO_gka1');
+                            Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked ...
+                                Data_LiveTrack.params.Report(rr).S2Tracked];
+                        else
+                            Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked_Ch01 ...
+                                Data_LiveTrack.params.Report(rr).PupilTracked_Ch02];
+                        end
+                    case 30
+                        Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr)];
+                        Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).LeftPupilWidth];
+                        Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked];
+                        
+                end
+            end
+            
+            % Now, we reconstruct the time vector of the data.
+            TTLPulseIndices = find(Data_LiveTrack_TTLPulses); FirstTTLPulse = TTLPulseIndices(1);
+            TimeVectorLinear = zeros(1, size(Data_LiveTrack_TTLPulses, 2));
+            TimeVectorLinear(TTLPulseIndices) = (1:params.NTRsExpected)-1;
+            
+            % Replace zeros with NaN
+            tmpX = 1:length(TimeVectorLinear);
+            TimeVectorLinear(TimeVectorLinear == 0) = NaN;
+            TimeVectorLinear(isnan(TimeVectorLinear)) = interp1(tmpX(~isnan(TimeVectorLinear)), ...
+                TimeVectorLinear(~isnan(TimeVectorLinear)), tmpX(isnan(TimeVectorLinear)), 'linear', 'extrap');
+            
+            % Resample the timing to 1 msecs sampling
+            Data_LiveTrack_PupilDiameter_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
+                Data_LiveTrack_PupilDiameter, params.TimeVectorFine);
+            Data_LiveTrack_IsTracked_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
+                Data_LiveTrack_IsTracked, params.TimeVectorFine, 'nearest'); % Use NN interpolation for the binary tracking state
+
+            % Extract the stimulus timing
+            keyPressWhich = [];
+            keyPressWhen = [];
+            for rr = 1:length(stimulus{i}.metaData.params.responseStruct.events)
+                keyPressWhich = [keyPressWhich stimulus{i}.metaData.params.responseStruct.events(rr).buffer.keyCode];
+                keyPressWhen = [keyPressWhen stimulus{i}.metaData.params.responseStruct.events(rr).buffer.when];
+            end
+            
+            % Extract only the ts
+            keyPressWhen = keyPressWhen(keyPressWhich == 18);
+            
+            % Tack the first t also in this vector
+            stimulus{i}.metaData_TTL = [stimulus{i}.metaData.params.responseStruct.tBlockStart keyPressWhen];
+            
+            % Subtract the absolute time of the first t
+            stimulus{i}.metaData_TTL_t0 = stimulus{i}.metaData_TTL(1);
+            stimulus{i}.metaData_TTL = stimulus{i}.metaData_TTL-stimulus{i}.metaData_TTL_t0;
+            
+            % Check that we have as many TRs as we expect
+            fprintf('> Expecting <strong>%g</strong> TRs - Found <strong>%g</strong> (LiveTrack) and <strong>%g</strong> (OneLight record).\n', ...
+                params.NTRsExpected, sum(Data_LiveTrack_TTLPulses), length(stimulus{i}.metaData_TTL));
+            if (params.NTRsExpected == sum(Data_LiveTrack_TTLPulses)) || (params.NTRsExpected == length(stimulus{i}.metaData_TTL))
+                fprintf('\t>> Expected number of TRs matches actual number.\n');
+            else
+                error('\t>> Mismatch between expected and actual number of TRs received.');
+            end
+            
+            % We now have four variables of interest
+            %   Data_LiveTrack_IsTracked_FineMasterTime <- Binary array indicating tracking state
+            %   Data_LiveTrack_PupilDiameter_FineMasterTime <- Pupil diameter
+            %   params.TimeVectorFine <- Time vector in TR time
+            
+            % Remove blinks from the pupil data
+            Data_LiveTrack_BlinkIdx = [];
+            for rr = 1:length(params.BlinkWindowSample)
+                Data_LiveTrack_BlinkIdx = [Data_LiveTrack_BlinkIdx find(~Data_LiveTrack_IsTracked_FineMasterTime)+params.BlinkWindowSample(rr)];
+            end
+            % Remove any blinks from before the first sample
+            Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx < 1) = []; %% ALSO CUT THE BLINKING OFF AT THE END
+            
+            % Remove any blinks after the last sample
+            Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx > length(Data_LiveTrack_IsTracked_FineMasterTime)) = []; %% ALSO CUT THE BLINKING OFF AT THE END
+            Data_LiveTrack_BlinkIdx = unique(Data_LiveTrack_BlinkIdx);
+            Data_LiveTrack_PupilDiameter_FineMasterTime(Data_LiveTrack_BlinkIdx) = NaN;
+            
+            % Interpolate the elements
+            Data_LiveTrack_PupilDiameter_FineMasterTime(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)) = interp1(params.TimeVectorFine(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), Data_LiveTrack_PupilDiameter_FineMasterTime(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), params.TimeVectorFine(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)));
+            % Get the DC
+            Data_LiveTrack_PupilDiameter_FineMasterTime_DC = nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime);
+            
+            Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered = (Data_LiveTrack_PupilDiameter_FineMasterTime-nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime))./(nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime));
+            
+            
+            % Low-pass filter the pupil data
+            % Set up filter properties
+            NFreqsToFilter = 8; % Number of low frequencies to remove
+            for ii = 1:NFreqsToFilter
+                X(2*ii-1,:) = sin(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
+                X(2*ii,:) = cos(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
+            end
+            
+            % Filter it
+            [b, bint, r] = regress(Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered',X');
+                subplot(3,1,1)
+                plot(params.TimeVectorFine, Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered)
+                subplot(3,1,2)
+                plot(params.TimeVectorFine, r)
+                subplot(3,1,3)
+                plot(params.TimeVectorFine, Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered-r')
+            
+            % Create the filtered version
+            Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f = r';
+            
+            % Add the DC back in
+            Data_LiveTrack_PupilDiameter_FineMasterTime_f = Data_LiveTrack_PupilDiameter_FineMasterTime_DC + ...
+                Data_LiveTrack_PupilDiameter_FineMasterTime_DC*Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f;
+        end
 end
 
 %% Saving data

--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -213,146 +213,11 @@ switch packetType
             
             switch sessionDate
                 case {'053116' '060116' '060216'}
-                    acquisitionFreq = 60;
+                    params.acquisitionFreq = 60;
                 otherwise
-                    acquisitionFreq = 30;
+                    params.acquisitionFreq = 30;
             end
-            
-            %
-            %%% EYE TRACKING DATA %%%
-            % Load the eye tracking data
-            Data_LiveTrack = load(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}));
-            
-            % Find cases in which the TTL pulse signal was split over the two
-            % samples, and remove the second sample.
-            Data_LiveTrack_TTLPulses_raw = [Data_LiveTrack.params.Report.Digital_IO1];
-            tmpIdx = strfind(Data_LiveTrack_TTLPulses_raw, [1 1]);
-            Data_LiveTrack_TTLPulses_raw(tmpIdx) = 0;
-            
-            Data_LiveTrack_TTLPulses = [];
-            Data_LiveTrack_PupilDiameter = [];
-            Data_LiveTrack_IsTracked = [];
-            % We reconstruct the data set collected at 30/60 Hz.
-            for rr = 1:length(Data_LiveTrack.params.Report)
-                % Depending on how we set up the acquisiton frequency, we have to
-                % do different things to extract the data
-                switch acquisitionFreq
-                    case 60
-                        Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr) 0];
-                        
-                        % We use the pupil width as the index of pupil diameter
-                        Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).PupilWidth_Ch01 ...
-                            Data_LiveTrack.params.Report(rr).PupilWidth_Ch02];
-                        
-                        % Special case
-                        if strcmp(dateID, '060616') && strcmp(subjectID, 'HERO_gka1');
-                            Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked ...
-                                Data_LiveTrack.params.Report(rr).S2Tracked];
-                        else
-                            Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked_Ch01 ...
-                                Data_LiveTrack.params.Report(rr).PupilTracked_Ch02];
-                        end
-                    case 30
-                        Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr)];
-                        Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).LeftPupilWidth];
-                        Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked];
-                        
-                end
-            end
-            
-            % Now, we reconstruct the time vector of the data.
-            TTLPulseIndices = find(Data_LiveTrack_TTLPulses); FirstTTLPulse = TTLPulseIndices(1);
-            TimeVectorLinear = zeros(1, size(Data_LiveTrack_TTLPulses, 2));
-            TimeVectorLinear(TTLPulseIndices) = (1:params.NTRsExpected)-1;
-            
-            % Replace zeros with NaN
-            tmpX = 1:length(TimeVectorLinear);
-            TimeVectorLinear(TimeVectorLinear == 0) = NaN;
-            TimeVectorLinear(isnan(TimeVectorLinear)) = interp1(tmpX(~isnan(TimeVectorLinear)), ...
-                TimeVectorLinear(~isnan(TimeVectorLinear)), tmpX(isnan(TimeVectorLinear)), 'linear', 'extrap');
-            
-            % Resample the timing to 1 msecs sampling
-            Data_LiveTrack_PupilDiameter_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
-                Data_LiveTrack_PupilDiameter, params.TimeVectorFine);
-            Data_LiveTrack_IsTracked_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
-                Data_LiveTrack_IsTracked, params.TimeVectorFine, 'nearest'); % Use NN interpolation for the binary tracking state
-
-            % Extract the stimulus timing
-            keyPressWhich = [];
-            keyPressWhen = [];
-            for rr = 1:length(stimulus{i}.metaData.params.responseStruct.events)
-                keyPressWhich = [keyPressWhich stimulus{i}.metaData.params.responseStruct.events(rr).buffer.keyCode];
-                keyPressWhen = [keyPressWhen stimulus{i}.metaData.params.responseStruct.events(rr).buffer.when];
-            end
-            
-            % Extract only the ts
-            keyPressWhen = keyPressWhen(keyPressWhich == 18);
-            
-            % Tack the first t also in this vector
-            stimulus{i}.metaData_TTL = [stimulus{i}.metaData.params.responseStruct.tBlockStart keyPressWhen];
-            
-            % Subtract the absolute time of the first t
-            stimulus{i}.metaData_TTL_t0 = stimulus{i}.metaData_TTL(1);
-            stimulus{i}.metaData_TTL = stimulus{i}.metaData_TTL-stimulus{i}.metaData_TTL_t0;
-            
-            % Check that we have as many TRs as we expect
-            fprintf('> Expecting <strong>%g</strong> TRs - Found <strong>%g</strong> (LiveTrack) and <strong>%g</strong> (OneLight record).\n', ...
-                params.NTRsExpected, sum(Data_LiveTrack_TTLPulses), length(stimulus{i}.metaData_TTL));
-            if (params.NTRsExpected == sum(Data_LiveTrack_TTLPulses)) || (params.NTRsExpected == length(stimulus{i}.metaData_TTL))
-                fprintf('\t>> Expected number of TRs matches actual number.\n');
-            else
-                error('\t>> Mismatch between expected and actual number of TRs received.');
-            end
-            
-            % We now have four variables of interest
-            %   Data_LiveTrack_IsTracked_FineMasterTime <- Binary array indicating tracking state
-            %   Data_LiveTrack_PupilDiameter_FineMasterTime <- Pupil diameter
-            %   params.TimeVectorFine <- Time vector in TR time
-            
-            % Remove blinks from the pupil data
-            Data_LiveTrack_BlinkIdx = [];
-            for rr = 1:length(params.BlinkWindowSample)
-                Data_LiveTrack_BlinkIdx = [Data_LiveTrack_BlinkIdx find(~Data_LiveTrack_IsTracked_FineMasterTime)+params.BlinkWindowSample(rr)];
-            end
-            % Remove any blinks from before the first sample
-            Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx < 1) = []; %% ALSO CUT THE BLINKING OFF AT THE END
-            
-            % Remove any blinks after the last sample
-            Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx > length(Data_LiveTrack_IsTracked_FineMasterTime)) = []; %% ALSO CUT THE BLINKING OFF AT THE END
-            Data_LiveTrack_BlinkIdx = unique(Data_LiveTrack_BlinkIdx);
-            Data_LiveTrack_PupilDiameter_FineMasterTime(Data_LiveTrack_BlinkIdx) = NaN;
-            
-            % Interpolate the elements
-            Data_LiveTrack_PupilDiameter_FineMasterTime(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)) = interp1(params.TimeVectorFine(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), Data_LiveTrack_PupilDiameter_FineMasterTime(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), params.TimeVectorFine(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)));
-            % Get the DC
-            Data_LiveTrack_PupilDiameter_FineMasterTime_DC = nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime);
-            
-            Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered = (Data_LiveTrack_PupilDiameter_FineMasterTime-nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime))./(nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime));
-            
-            
-            % Low-pass filter the pupil data
-            % Set up filter properties
-            NFreqsToFilter = 8; % Number of low frequencies to remove
-            for ii = 1:NFreqsToFilter
-                X(2*ii-1,:) = sin(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
-                X(2*ii,:) = cos(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
-            end
-            
-            % Filter it
-            [b, bint, r] = regress(Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered',X');
-                subplot(3,1,1)
-                plot(params.TimeVectorFine, Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered)
-                subplot(3,1,2)
-                plot(params.TimeVectorFine, r)
-                subplot(3,1,3)
-                plot(params.TimeVectorFine, Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered-r')
-            
-            % Create the filtered version
-            Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f = r';
-            
-            % Add the DC back in
-            Data_LiveTrack_PupilDiameter_FineMasterTime_f = Data_LiveTrack_PupilDiameter_FineMasterTime_DC + ...
-                Data_LiveTrack_PupilDiameter_FineMasterTime_DC*Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f;
+            response{i}.values = loadPupilDataForPackets(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}), stimulus, params);
         end
 end
 
@@ -369,9 +234,6 @@ switch packetType
         save(fullfile(saveDir,[roiType '.mat']),'packets','-v7.3');
         
     case 'pupil'
-        %% Do a bunch of pupil-related things
-        %
-        
         %% Save outputs
         for i = 1:length(runDirs)
             packets{i}.stimulus     = stimulus{i};

--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -48,13 +48,16 @@ switch packetType
         bbregName           = 'func_bbreg.dat';
         % HRF defaults
         hrfDir              = fullfile(sessionDir,'HRF');
+        % response files
+        runDirs             = find_bold(sessionDir);
+    case 'pupil'
+        runDirs = listdir(fullfile(sessionDir, 'EyeTrackingFiles/*.mat'), 'files');
 end
 
 % stimulus files
 matDir              = fullfile(sessionDir,'MatFiles');
 matFiles            = listdir(matDir,'files');
-% response files
-runDirs             = find_bold(sessionDir);
+
 % save directory
 saveDir             = fullfile(sessionDir,'Packets');
 if ~exist(saveDir,'dir')
@@ -70,7 +73,12 @@ for i = 1:length(runDirs)
     metaData{i}.subjectName     = subjectName;
     metaData{i}.sessionDate     = sessionDate;
     metaData{i}.stimulusFile    = fullfile(matDir,matFiles{i});
-    metaData{i}.responseFile    = fullfile(sessionDir,runDirs{i},[func '.nii.gz']);
+    switch packetType
+        case 'bold'
+            metaData{i}.responseFile    = fullfile(sessionDir,runDirs{i},[func '.nii.gz']);
+        case 'pupil'
+            metaData{i}.responseFile = fullfile(sessionDir,runDirs{i});
+    end
 end
 
 

--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -217,7 +217,7 @@ switch packetType
                 otherwise
                     params.acquisitionFreq = 30;
             end
-            response{i}.values = loadPupilDataForPackets(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}), stimulus, params);
+            response{i}.values = loadPupilDataForPackets(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}), stimulus{i}, params);
         end
 end
 

--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -213,9 +213,9 @@ switch packetType
             
             switch sessionDate
                 case {'053116' '060116' '060216'}
-                    params.acquisitionFreq = 60;
-                otherwise
                     params.acquisitionFreq = 30;
+                otherwise
+                    params.acquisitionFreq = 60;
             end
             response{i}.values = loadPupilDataForPackets(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}), stimulus{i}, params);
         end
@@ -240,5 +240,5 @@ switch packetType
             packets{i}.response     = response{i};
             packets{i}.metaData     = metaData{i};
         end
-        save(fullfile(saveDir,'.mat'),'packets','-v7.3');
+        save(fullfile(saveDir,'PupilPacket.mat'),'packets','-v7.3');
 end

--- a/BDCMToolbox/makePackets.m
+++ b/BDCMToolbox/makePackets.m
@@ -14,10 +14,6 @@ function packets = makePackets(sessionDir,packetType,roiType,func)
 %   response.timebase       - 1 x TR vector of response times (msec)
 %   response.metaData       - structure with info about the response
 %
-%   HRF.values              - 1 x N vector of response values
-%   HRF.timebase            - 1 x N vector of response times (msec)
-%   HRF.metaData            - structure with info about the HRF
-%
 %   metaData.projectName    - project name (e.g. 'MelanopsinMR');
 %   metaData.subjectName    - subject name (e.g. 'HERO_asb1');
 %   metaData.sessionDate    - session date (e.g. '041416');

--- a/BDCMToolbox/pupilFuncs/loadPupilDataForPackets.m
+++ b/BDCMToolbox/pupilFuncs/loadPupilDataForPackets.m
@@ -1,0 +1,130 @@
+function values = loadPupilDataForPackets(input_dir, stimulus, params)
+% values = loadPupilDataForPackets(input_dir, stimulus, params)
+
+%%% EYE TRACKING DATA %%%
+% Load the eye tracking data
+Data_LiveTrack = load(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}));
+
+% Find cases in which the TTL pulse signal was split over the two
+% samples, and remove the second sample.
+Data_LiveTrack_TTLPulses_raw = [Data_LiveTrack.params.Report.Digital_IO1];
+tmpIdx = strfind(Data_LiveTrack_TTLPulses_raw, [1 1]);
+Data_LiveTrack_TTLPulses_raw(tmpIdx) = 0;
+
+Data_LiveTrack_TTLPulses = [];
+Data_LiveTrack_PupilDiameter = [];
+Data_LiveTrack_IsTracked = [];
+% We reconstruct the data set collected at 30/60 Hz.
+for rr = 1:length(Data_LiveTrack.params.Report)
+    % Depending on how we set up the acquisiton frequency, we have to
+    % do different things to extract the data
+    switch params.acquisitionFreq
+        case 60
+            Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr) 0];
+            
+            % We use the pupil width as the index of pupil diameter
+            Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).PupilWidth_Ch01 ...
+                Data_LiveTrack.params.Report(rr).PupilWidth_Ch02];
+            
+            % Special case
+            if strcmp(dateID, '060616') && strcmp(subjectID, 'HERO_gka1');
+                Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked ...
+                    Data_LiveTrack.params.Report(rr).S2Tracked];
+            else
+                Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked_Ch01 ...
+                    Data_LiveTrack.params.Report(rr).PupilTracked_Ch02];
+            end
+        case 30
+            Data_LiveTrack_TTLPulses = [Data_LiveTrack_TTLPulses Data_LiveTrack_TTLPulses_raw(rr)];
+            Data_LiveTrack_PupilDiameter = [Data_LiveTrack_PupilDiameter Data_LiveTrack.params.Report(rr).LeftPupilWidth];
+            Data_LiveTrack_IsTracked = [Data_LiveTrack_IsTracked Data_LiveTrack.params.Report(rr).PupilTracked];
+            
+    end
+end
+
+% Now, we reconstruct the time vector of the data.
+TTLPulseIndices = find(Data_LiveTrack_TTLPulses); FirstTTLPulse = TTLPulseIndices(1);
+TimeVectorLinear = zeros(1, size(Data_LiveTrack_TTLPulses, 2));
+TimeVectorLinear(TTLPulseIndices) = (1:params.NTRsExpected)-1;
+
+% Replace zeros with NaN
+tmpX = 1:length(TimeVectorLinear);
+TimeVectorLinear(TimeVectorLinear == 0) = NaN;
+TimeVectorLinear(isnan(TimeVectorLinear)) = interp1(tmpX(~isnan(TimeVectorLinear)), ...
+    TimeVectorLinear(~isnan(TimeVectorLinear)), tmpX(isnan(TimeVectorLinear)), 'linear', 'extrap');
+
+% Resample the timing to 1 msecs sampling
+Data_LiveTrack_PupilDiameter_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
+    Data_LiveTrack_PupilDiameter, params.TimeVectorFine);
+Data_LiveTrack_IsTracked_FineMasterTime = interp1(TimeVectorLinear*params.TRDurSecs*1000, ...
+    Data_LiveTrack_IsTracked, params.TimeVectorFine, 'nearest'); % Use NN interpolation for the binary tracking state
+
+% Extract the stimulus timing
+keyPressWhich = [];
+keyPressWhen = [];
+for rr = 1:length(stimulus{i}.metaData.params.responseStruct.events)
+    keyPressWhich = [keyPressWhich stimulus{i}.metaData.params.responseStruct.events(rr).buffer.keyCode];
+    keyPressWhen = [keyPressWhen stimulus{i}.metaData.params.responseStruct.events(rr).buffer.when];
+end
+
+% Extract only the ts
+keyPressWhen = keyPressWhen(keyPressWhich == 18);
+
+% Tack the first t also in this vector
+stimulus{i}.metaData_TTL = [stimulus{i}.metaData.params.responseStruct.tBlockStart keyPressWhen];
+
+% Subtract the absolute time of the first t
+stimulus{i}.metaData_TTL_t0 = stimulus{i}.metaData_TTL(1);
+stimulus{i}.metaData_TTL = stimulus{i}.metaData_TTL-stimulus{i}.metaData_TTL_t0;
+
+% Check that we have as many TRs as we expect
+fprintf('> Expecting <strong>%g</strong> TRs - Found <strong>%g</strong> (LiveTrack) and <strong>%g</strong> (OneLight record).\n', ...
+    params.NTRsExpected, sum(Data_LiveTrack_TTLPulses), length(stimulus{i}.metaData_TTL));
+if (params.NTRsExpected == sum(Data_LiveTrack_TTLPulses)) || (params.NTRsExpected == length(stimulus{i}.metaData_TTL))
+    fprintf('\t>> Expected number of TRs matches actual number.\n');
+else
+    error('\t>> Mismatch between expected and actual number of TRs received.');
+end
+
+% We now have four variables of interest
+%   Data_LiveTrack_IsTracked_FineMasterTime <- Binary array indicating tracking state
+%   Data_LiveTrack_PupilDiameter_FineMasterTime <- Pupil diameter
+%   params.TimeVectorFine <- Time vector in TR time
+
+% Remove blinks from the pupil data
+Data_LiveTrack_BlinkIdx = [];
+for rr = 1:length(params.BlinkWindowSample)
+    Data_LiveTrack_BlinkIdx = [Data_LiveTrack_BlinkIdx find(~Data_LiveTrack_IsTracked_FineMasterTime)+params.BlinkWindowSample(rr)];
+end
+% Remove any blinks from before the first sample
+Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx < 1) = []; %% ALSO CUT THE BLINKING OFF AT THE END
+
+% Remove any blinks after the last sample
+Data_LiveTrack_BlinkIdx(Data_LiveTrack_BlinkIdx > length(Data_LiveTrack_IsTracked_FineMasterTime)) = []; %% ALSO CUT THE BLINKING OFF AT THE END
+Data_LiveTrack_BlinkIdx = unique(Data_LiveTrack_BlinkIdx);
+Data_LiveTrack_PupilDiameter_FineMasterTime(Data_LiveTrack_BlinkIdx) = NaN;
+
+% Interpolate the elements
+Data_LiveTrack_PupilDiameter_FineMasterTime(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)) = interp1(params.TimeVectorFine(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), Data_LiveTrack_PupilDiameter_FineMasterTime(~isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)), params.TimeVectorFine(isnan(Data_LiveTrack_PupilDiameter_FineMasterTime)));
+% Get the DC
+Data_LiveTrack_PupilDiameter_FineMasterTime_DC = nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime);
+
+Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered = (Data_LiveTrack_PupilDiameter_FineMasterTime-nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime))./(nanmean(Data_LiveTrack_PupilDiameter_FineMasterTime));
+
+%%
+% Low-pass filter the pupil data
+% Set up filter properties
+NFreqsToFilter = 8; % Number of low frequencies to remove
+X = [];
+for ii = 1:NFreqsToFilter
+    X(2*ii-1,:) = sin(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
+    X(2*ii,:) = cos(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
+end
+
+% Filter it
+[b, bint, r] = regress(Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered',X');
+
+% Create the filtered version
+Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f = r';
+Data_LiveTrack_PupilDiameter_FineMasterTime_LowFreq = Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered-r';
+values = Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered_f;

--- a/BDCMToolbox/pupilFuncs/loadPupilDataForPackets.m
+++ b/BDCMToolbox/pupilFuncs/loadPupilDataForPackets.m
@@ -3,7 +3,7 @@ function values = loadPupilDataForPackets(input_dir, stimulus, params)
 
 %%% EYE TRACKING DATA %%%
 % Load the eye tracking data
-Data_LiveTrack = load(fullfile(sessionDir, 'EyeTrackingFiles', runDirs{i}));
+Data_LiveTrack = load(input_dir);
 
 % Find cases in which the TTL pulse signal was split over the two
 % samples, and remove the second sample.
@@ -62,25 +62,25 @@ Data_LiveTrack_IsTracked_FineMasterTime = interp1(TimeVectorLinear*params.TRDurS
 % Extract the stimulus timing
 keyPressWhich = [];
 keyPressWhen = [];
-for rr = 1:length(stimulus{i}.metaData.params.responseStruct.events)
-    keyPressWhich = [keyPressWhich stimulus{i}.metaData.params.responseStruct.events(rr).buffer.keyCode];
-    keyPressWhen = [keyPressWhen stimulus{i}.metaData.params.responseStruct.events(rr).buffer.when];
+for rr = 1:length(stimulus.metaData.params.responseStruct.events)
+    keyPressWhich = [keyPressWhich stimulus.metaData.params.responseStruct.events(rr).buffer.keyCode];
+    keyPressWhen = [keyPressWhen stimulus.metaData.params.responseStruct.events(rr).buffer.when];
 end
 
 % Extract only the ts
 keyPressWhen = keyPressWhen(keyPressWhich == 18);
 
 % Tack the first t also in this vector
-stimulus{i}.metaData_TTL = [stimulus{i}.metaData.params.responseStruct.tBlockStart keyPressWhen];
+stimulus.metaData_TTL = [stimulus.metaData.params.responseStruct.tBlockStart keyPressWhen];
 
 % Subtract the absolute time of the first t
-stimulus{i}.metaData_TTL_t0 = stimulus{i}.metaData_TTL(1);
-stimulus{i}.metaData_TTL = stimulus{i}.metaData_TTL-stimulus{i}.metaData_TTL_t0;
+stimulus.metaData_TTL_t0 = stimulus.metaData_TTL(1);
+stimulus.metaData_TTL = stimulus.metaData_TTL-stimulus.metaData_TTL_t0;
 
 % Check that we have as many TRs as we expect
 fprintf('> Expecting <strong>%g</strong> TRs - Found <strong>%g</strong> (LiveTrack) and <strong>%g</strong> (OneLight record).\n', ...
-    params.NTRsExpected, sum(Data_LiveTrack_TTLPulses), length(stimulus{i}.metaData_TTL));
-if (params.NTRsExpected == sum(Data_LiveTrack_TTLPulses)) || (params.NTRsExpected == length(stimulus{i}.metaData_TTL))
+    params.NTRsExpected, sum(Data_LiveTrack_TTLPulses), length(stimulus.metaData_TTL));
+if (params.NTRsExpected == sum(Data_LiveTrack_TTLPulses)) || (params.NTRsExpected == length(stimulus.metaData_TTL))
     fprintf('\t>> Expected number of TRs matches actual number.\n');
 else
     error('\t>> Mismatch between expected and actual number of TRs received.');
@@ -117,8 +117,8 @@ Data_LiveTrack_PupilDiameter_FineMasterTime_MeanCentered = (Data_LiveTrack_Pupil
 NFreqsToFilter = 8; % Number of low frequencies to remove
 X = [];
 for ii = 1:NFreqsToFilter
-    X(2*ii-1,:) = sin(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
-    X(2*ii,:) = cos(linspace(0, 2*pi*ii, size(stimulus{i}.timebase, 2)));
+    X(2*ii-1,:) = sin(linspace(0, 2*pi*ii, size(stimulus.timebase, 2)));
+    X(2*ii,:) = cos(linspace(0, 2*pi*ii, size(stimulus.timebase, 2)));
 end
 
 % Filter it


### PR DESCRIPTION
- I've implemented some machinery to treat pupil data in terms of packets. This is solved programmatically using switch statements operating on the `packetType` input arg. 
- Note that the variable `packetType` previously contained the ROI (i.e. 'V1', 'V2V3', 'LGN'), but that is now in `roiType`. So, whichever functions that call `makePackets` should be updated accordingly to reflect this.
- In the part of the code that extracts parameters about the cosine windowing, in previous versions there was bug which did not index into the `stimulus` cell appropriately. This is now fixed.
