### PR TITLE
Implementation of 1-Rsquared as an error metric

### DIFF
--- a/Models/IAMPModel/@tfeIAMP/computeResponse.m
+++ b/Models/IAMPModel/@tfeIAMP/computeResponse.m
@@ -16,6 +16,7 @@ p = inputParser;
 p.addRequired('params',@isstruct);
 p.addRequired('stimulusStruct',@isstruct);
 p.addRequired('kernelStruct',@(x)(isempty(x) || isstruct(x)));
+p.addParameter('errorType','rmse',@ischar);
 p.addParameter('addNoise',false,@islogical);
 p.parse(params,stimulusStruct,kernelStruct,varargin{:});
 params = p.Results.params;

--- a/temporalFittingEngine/@tfe/fitError.m
+++ b/temporalFittingEngine/@tfe/fitError.m
@@ -10,10 +10,11 @@ function [fVal,modelResponseStruct] = fitError(obj,paramsVec,thePacket,varargin)
 % Optional key/value pairs
 %  'errorType' - string (default 'rmse') Type of error to compute.
 %    'rmse' - Root mean squared error.
+%    '1-r2' - 1-R2
 %
 % Outputs: 
 %   fVal: mean value of fit error, mean taken over runs.
-%   modelResponsStruct: predicted response, standard structure form
+%   modelResponseStruct: predicted response, standard structure form
 
 %% Parse vargin for options passed here
 p = inputParser;
@@ -35,6 +36,8 @@ modelResponseStruct = obj.resampleTimebase(modelResponseStruct,thePacket.respons
 switch (p.Results.errorType)
     case 'rmse'
         fVal = sqrt(mean((modelResponseStruct.values-thePacket.response.values).^2));
+    case '1-r2'
+        fVal = sum((thePacket.response.values - modelResponseStruct.values).^2)/sum((thePacket.response.values - mean(thePacket.response.values)).^2);
     otherwise
         error('Unknown error type passed');
 end

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -30,6 +30,7 @@ p.addRequired('thePacket',@isstruct);
 p.addParameter('defaultParamsInfo',[],@(x)(isempty(x) | isstruct(x)));
 p.addParameter('paramLockMatrix',[],@isnumeric);
 p.addParameter('searchMethod','fmincon',@ischar);
+p.addParameter('errorType','rmse',@ischar);
 p.parse(thePacket,varargin{:});
 
 % Check packet validity
@@ -95,7 +96,7 @@ switch (p.Results.searchMethod)
 end
 
 % Get error and predicted response for final parameters
-[fVal,modelResponseStruct] = obj.fitError(paramsFitVec,thePacket);
+[fVal,modelResponseStruct] = obj.fitError(paramsFitVec,thePacket,'errorType',p.Results.errorType);
 
 switch (obj.verbosity)
     case 'high'

--- a/temporalFittingEngine/@tfe/resampleTimebase.m
+++ b/temporalFittingEngine/@tfe/resampleTimebase.m
@@ -19,6 +19,7 @@ function resampledStruct= resampleTimebase(obj,inputStruct,newTimebase,varargin)
 p = inputParser;
 p.addRequired('inputStruct',@isstruct);
 p.addRequired('newTimebase',@isnumeric);
+p.addParameter('errorType', 'rmse', @ischar);
 p.addParameter('method','interp1_linear',@ischar);
 p.parse(inputStruct,newTimebase,varargin{:});
 


### PR DESCRIPTION
I've implemented 1-Rsquared as an error metric. I'm not sure if it was necessary to add the `errorType` key into those functions and am hoping someone deeper in the code (@DavidBrainard, @gkaguirre, @benchinny) could take a look at this.
