### PR TITLE
Handle nans in convolution

### DIFF
--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -75,11 +75,145 @@ for ii=1:nRows
     % Convolve a row of inputStruct.values with the kernel.  The
     % convolutoin is a discrete approximation to an intergral, so we
     % explicitly include the factor of responseDeltaT.
-    valuesRowConv = conv(inputStruct.values(ii,:),kernelStruct.values,'full')*responseDeltaT;
+    
+    % old method
+    valuesRowConv = conv(inputStruct.values(ii,:),kernelStruct.values, 'full')*responseDeltaT;
+    
+    % new nan-safe method
+    valuesRowConv = nanconv_local(inputStruct.values(ii,:),kernelStruct.values, '1d')*responseDeltaT;
+    
     
     % Cut off extra conv values
-    outputStruct.values(ii,:) = valuesRowConv(1:length(inputStruct.timebase));  
-end 
+    outputStruct.values(ii,:) = valuesRowConv(1:length(inputStruct.timebase));
+end
+
+%% Local function nanconv
+% from matlab central, with a few modifications to force the shape of the
+% convolution be 'full', rather than 'same' which is all the built-in
+% capacity the initial function has
+    function c = nanconv_local(a, k, varargin)
+        % NANCONV Convolution in 1D or 2D ignoring NaNs.
+        %   C = NANCONV(A, K) convolves A and K, correcting for any NaN values
+        %   in the input vector A. The result is the same size as A (as though you
+        %   called 'conv' or 'conv2' with the 'same' shape).
+        %
+        %   C = NANCONV(A, K, 'param1', 'param2', ...) specifies one or more of the following:
+        %     'edge'     - Apply edge correction to the output.
+        %     'noedge'   - Do not apply edge correction to the output (default).
+        %     'nanout'   - The result C should have NaNs in the same places as A.
+        %     'nonanout' - The result C should have ignored NaNs removed (default).
+        %                  Even with this option, C will have NaN values where the
+        %                  number of consecutive NaNs is too large to ignore.
+        %     '2d'       - Treat the input vectors as 2D matrices (default).
+        %     '1d'       - Treat the input vectors as 1D vectors.
+        %                  This option only matters if 'a' or 'k' is a row vector,
+        %                  and the other is a column vector. Otherwise, this
+        %                  option has no effect.
+        %
+        %   NANCONV works by running 'conv2' either two or three times. The first
+        %   time is run on the original input signals A and K, except all the
+        %   NaN values in A are replaced with zeros. The 'same' input argument is
+        %   used so the output is the same size as A. The second convolution is
+        %   done between a matrix the same size as A, except with zeros wherever
+        %   there is a NaN value in A, and ones everywhere else. The output from
+        %   the first convolution is normalized by the output from the second
+        %   convolution. This corrects for missing (NaN) values in A, but it has
+        %   the side effect of correcting for edge effects due to the assumption of
+        %   zero padding during convolution. When the optional 'noedge' parameter
+        %   is included, the convolution is run a third time, this time on a matrix
+        %   of all ones the same size as A. The output from this third convolution
+        %   is used to restore the edge effects. The 'noedge' parameter is enabled
+        %   by default so that the output from 'nanconv' is identical to the output
+        %   from 'conv2' when the input argument A has no NaN values.
+        %
+        % See also conv, conv2
+        %
+        % AUTHOR: Benjamin Kraus (bkraus@bu.edu, ben@benkraus.com)
+        % Copyright (c) 2013, Benjamin Kraus
+        % $Id: nanconv.m 4861 2013-05-27 03:16:22Z bkraus $
+        
+        % Process input arguments
+        for arg = 1:nargin-2
+            switch lower(varargin{arg})
+                case 'edge'; edge = true; % Apply edge correction
+                case 'noedge'; edge = false; % Do not apply edge correction
+                case {'same','full','valid'}; shape = varargin{arg}; % Specify shape
+                case 'nanout'; nanout = true; % Include original NaNs in the output.
+                case 'nonanout'; nanout = false; % Do not include NaNs in the output.
+                case {'2d','is2d'}; is1D = false; % Treat the input as 2D
+                case {'1d','is1d'}; is1D = true; % Treat the input as 1D
+            end
+        end
+        
+        % Apply default options when necessary.
+        if(exist('edge','var')~=1); edge = false; end
+        if(exist('nanout','var')~=1); nanout = false; end
+        if(exist('is1D','var')~=1); is1D = false; end
+        if(exist('shape','var')~=1); shape = 'same';
+        elseif(~strcmp(shape,'same'))
+            error([mfilename ':NotImplemented'],'Shape ''%s'' not implemented',shape);
+        end
+        shape = 'full'
+        
+        % Get the size of 'a' for use later.
+        sza = size(a);
+        
+        % If 1D, then convert them both to columns.
+        % This modification only matters if 'a' or 'k' is a row vector, and the
+        % other is a column vector. Otherwise, this argument has no effect.
+        if(is1D);
+            if(~isvector(a) || ~isvector(k))
+                error('MATLAB:conv:AorBNotVector','A and B must be vectors.');
+            end
+            a = a(:); k = k(:);
+        end
+        
+        % Flat function for comparison.
+        o = ones(size(a));
+        
+        % Flat function with NaNs for comparison.
+        on = ones(size(a));
+        
+        % Find all the NaNs in the input.
+        n = isnan(a);
+        
+        % Replace NaNs with zero, both in 'a' and 'on'.
+        a(n) = 0;
+        on(n) = 0;
+        
+        % Check that the filter does not have NaNs.
+        if(any(isnan(k)));
+            error([mfilename ':NaNinFilter'],'Filter (k) contains NaN values.');
+        end
+        
+        % Calculate what a 'flat' function looks like after convolution.
+        if(any(n(:)) || edge)
+            flat = conv2(on,k,shape);
+            flat = flat(1:length(a));
+        else flat = o;
+        end
+        
+        % The line above will automatically include a correction for edge effects,
+        % so remove that correction if the user does not want it.
+        if(any(n(:)) && ~edge);
+            flatScaler = conv2(o,k,shape);
+            flatScaler = flatScaler(1:length(a));
+            flat = flat./flatScaler;
+        end
+        
+        % Do the actual convolution
+        c = conv2(a,k,shape);
+        c = c(1:length(a));
+        c = c./flat;
+        
+        % If requested, replace output values with NaNs corresponding to input.
+        if(nanout); c(n) = NaN; end
+        
+        % If 1D, convert back to the original shape.
+        if(is1D && sza(1) == 1); c = c.'; end
+        
+    end
+
 
 end
 

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -163,7 +163,7 @@ end
         elseif(~strcmp(shape,'same'))
             error([mfilename ':NotImplemented'],'Shape ''%s'' not implemented',shape);
         end
-        shape = 'full'
+        shape = 'full';
         
         % Get the size of 'a' for use later.
         sza = size(a);

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -91,6 +91,33 @@ for ii=1:nRows
         % values, so we don't need to do it after
     end
     
+    % principled method: If the missle values are within the temporal
+    % domain of the kernel (the length of time that the kernel spans), we
+    % will interpolate the missing values and continue with the convolution
+    % as normal. If, however, the length of the stretch of NaN values is
+    % greater than the domain of the kernel, we will assign the
+    % corresponding region of the output vector to be NaN as well.
+    
+    if strcmp(p.Results.convolveMethod, 'principled')
+        % identify any NaN values
+        NaNIndices = find(isnan(inputStruct.values(ii,:)));
+        
+        % determine the length of each NaN segment
+        
+        % interpolate over NaN segments that are short enough in duration,
+        % relative to kernel temporal domain
+        
+        % lingering question: how to handle the convolution when we will
+        % not be interpolating
+        % 1st option: interpolate, then convolve, then replace these indices
+        % with NaN
+        % 2nd option: keep NaN, use nanconv, then replace these indices
+        % with NaN.
+        % These two options will produce different results for values along
+        % the edges of these NaN segments
+        
+    end
+    
     
    
 end

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -143,6 +143,9 @@ end
         % $Id: nanconv.m 4861 2013-05-27 03:16:22Z bkraus $
         
         % Process input arguments
+
+        
+        
         for arg = 1:nargin-2
             switch lower(varargin{arg})
                 case 'edge'; edge = true; % Apply edge correction
@@ -214,7 +217,23 @@ end
         % Do the actual convolution
         c = conv2(a,k,shape);
         c = c(1:length(a));
+        
+        makePlots = true;
+        if (makePlots)
+            plotFig = figure;
+            hold on
+            plot(c)
+            plot(flat)
+        end
+        
+        
+        
         c = c./flat;
+        if (makePlots)
+            plot(c)
+            legend('First Convolution: NaNs set to 0', 'Second Convolution: NaNs set to 0, everyting else at 1', 'Final Output (First/Second Convolution)')
+            title('Debug nanconv')
+        end
         
         % If requested, replace output values with NaNs corresponding to input.
         if(nanout); c(n) = NaN; end

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -1,28 +1,63 @@
 function [outputStruct,kernelStruct] = applyKernel(obj,inputStruct,kernelStruct,varargin)
-% [outputStruct,kernelStruct] = applyKernel(obj,modelResponseStruct,kernelStruct,varargin)
+% Apply a convolution kernel to a passed inputStruct
 %
-% Apply a convolution kernel to a modeled response. In a typical
-% application, this will be a hemodynamic response function applied to
-% a model of neural activity to produce a BOLD fMRI response.
+% Syntax:
+%  [outputStruct,kernelStruct] = applyKernel(obj,modelResponseStruct,kernelStruct,varargin)
 %
-% The outputStruct's values field has the result of the convolution, and
-% its timebase matches that of the input struct.
+% Description:
+%	Apply a convolution kernel to a modeled response. In a typical
+%   application, this will be a hemodynamic response function applied to a
+%   model of neural activity to produce a BOLD fMRI response.
 %
-% The returned kernelStruct is the input, but if necessary its timebase has
-% and values have been resampled to have the same delta time as the
-% inputStruct's timebase.  The duration of the resampled kernel is at least
-% as long as the original, and can be a little longer if the resampling
-% requires an extension to produce an integer number of resampled times.
-% This is returned mostly for debugging and checking purposes.
+%   The outputStruct's values field has the result of the convolution, and
+%   its timebase matches that of the input struct.
 %
-% Both modelResponseStruct and kernelStruct arguments are structures, containing
-% timebase and values fields.  The timebases do not need to be the same, but
-% each must be regularly sampled.
+%   The returned kernelStruct is the input, but if necessary its timebase
+%   has and values have been resampled to have the same delta time as the
+%   inputStruct's timebase.  The duration of the resampled kernel is at
+%   least as long as the original, and can be a little longer if the
+%   resampling requires an extension to produce an integer number of
+%   resampled times. This is returned mostly for debugging and checking
+%   purposes.
+%
+%   Both modelResponseStruct and kernelStruct arguments are structures,
+%   containing timebase and values fields.  The timebases do not need to be
+%   the same, but each must be regularly sampled.
+%
+% Inputs
+%   inputStruct           - F
+%   kernelStruct          - F
 %
 % Optional key/value pairs
-%   'method' - string (default 'interp1_linear').  How to resample kernel timebase,
-%      if needed.  This is passed onto method resampleTimebase.
-%     'interp1_linear' - Use Matlab's interp1, linear method.
+%  'method'               - String (default 'interp1_linear').  How to
+%                           resample kernel timebase, if needed. This is
+%                           passed onto method resampleTimebase.
+%  'interp1_linear'       - Use Matlab's interp1, linear method.
+%
+% Outputs
+%   outputStruct          - F
+%   kernelStruct          - F
+%
+% Examples:
+%{
+    % Standard convolution. Test result against cached value.
+    % We create a delta function response and a double-gamma HRF
+    responseStruct.timebase = 0:1:25999;
+	responseStruct.values = zeros(1,length(responseStruct.timebase));
+	responseStruct.values(2000) = 1;
+    kernelStruct.timebase=linspace(0,15999,16000);
+    hrf = gampdf(kernelStruct.timebase/1000, 6, 1) -  gampdf(kernelStruct.timebase/1000, 12, 1)/10;
+    kernelStruct.values=hrf;
+    [ kernelStruct ] = normalizeKernelArea( kernelStruct );
+    % Instantiate the tfe and perform the convolution
+    temporalFit = tfeIAMP('verbosity','none');
+    convResponseStruct = temporalFit.applyKernel(responseStruct,kernelStruct);
+    % Compare the output to a cached hash of the output
+    cachedHash = '41d0741a71e625ecc91c67f227017425';
+    computedHash = DataHash(convResponseStruct);
+    assert(strcmp(computedHash, cachedHash));
+%}
+
 
 %% Parse vargin for options passed here
 %
@@ -32,7 +67,7 @@ function [outputStruct,kernelStruct] = applyKernel(obj,inputStruct,kernelStruct,
 p = inputParser; p.KeepUnmatched = true; p.PartialMatching = false;
 p.addRequired('inputStruct',@isstruct);
 p.addRequired('kernelStruct',@(x)(isempty(x) | isstruct(x)));
-p.addParameter('convolveMethod', 'conv', @ischar);
+p.addRequired('durationMsecsOfNansToCensor',5000,@isscalar);
 p.parse(inputStruct,kernelStruct,varargin{:});
 
 %% Propagate all fields forward
@@ -71,206 +106,80 @@ if (responseDeltaT ~= kernelDeltaT)
     kernelStruct = obj.resampleTimebase(kernelStruct,newKernelTimebase,varargin{:});
 end
 
+%% Find the time of the absolute maximum of the kernel
+% This may be used if we are handling nan values in the input below
+% DO THIS HERE
+
+
 %% Loop over rows for the convolution
 for ii=1:nRows
-    % Convolve a row of inputStruct.values with the kernel.  The
-    % convolutoin is a discrete approximation to an intergral, so we
-    % explicitly include the factor of responseDeltaT.
-    
-    % old method
-    if strcmp(p.Results.convolveMethod, 'conv')
-        valuesRowConv = conv(inputStruct.values(ii,:),kernelStruct.values, 'full')*responseDeltaT;
-        % Cut off extra conv values
-        outputStruct.values(ii,:) = valuesRowConv(1:length(inputStruct.timebase));
+
+    % Grab this row of the input structure
+    inputRow = inputStruct.values(ii,:);
+
+    % Detect if nans are present in this row of values
+    nanIdx = isnan(inputRow);
+    if ~isempty(nanIdx)
+        % There are nans present. Spline interpolate over the missing
+        % values
+        inputRow=spline(inputStruct.timebase(~nanIdx), inputRow(~nanIdx), inputStruct.timebase);
     end
+
+    % Convolve with the kernel.  The convolution is a discrete
+    % approximation to an intergral, so we explicitly include the factor of
+    % responseDeltaT.
+    valuesRowConv = conv(inputRow,kernelStruct.values, 'full')*responseDeltaT;
+
+    % Cut off extra conv values
+    outputStruct.values(ii,:) = valuesRowConv(1:length(inputStruct.timebase));
     
-    % new nan-safe method
-    if strcmp(p.Results.convolveMethod, 'nanconv')
-        outputStruct.values(ii,:) = nanconv_local(inputStruct.values(ii,:),kernelStruct.values, '1d')*responseDeltaT;
-        % note that this function already cuts off the extra convolve
-        % values, so we don't need to do it after
+    % If nans were present in the input vector, find those stretches of
+    % nans that are longer than the passed threshold and set the output
+    % vector to have nans in the corresponding, temporally shifted
+    % location.
+    if ~isempty(nanIdx)
+        % Find the stretches
+        % nan the outputStruct.values at the corresponding delayed
+        % locations
     end
+
+    %     % new nan-safe method
+    %     if strcmp(p.Results.convolveMethod, 'nanconv')
+    %         outputStruct.values(ii,:) = nanconv_local(inputStruct.values(ii,:),kernelStruct.values, '1d')*responseDeltaT;
+    %         % note that this function already cuts off the extra convolve
+    %         % values, so we don't need to do it after
+    %     end
+    %
+    %     % principled method: If the missle values are within the temporal
+    %     % domain of the kernel (the length of time that the kernel spans), we
+    %     % will interpolate the missing values and continue with the convolution
+    %     % as normal. If, however, the length of the stretch of NaN values is
+    %     % greater than the domain of the kernel, we will assign the
+    %     % corresponding region of the output vector to be NaN as well.
+    %
+    %     if strcmp(p.Results.convolveMethod, 'principled')
+    %         % identify any NaN values
+    %         NaNIndices = find(isnan(inputStruct.values(ii,:)));
+    %
+    %         % determine the length of each NaN segment
+    %
+    %         % interpolate over NaN segments that are short enough in duration,
+    %         % relative to kernel temporal domain
+    %
+    %         % lingering question: how to handle the convolution when we will
+    %         % not be interpolating
+    %         % 1st option: interpolate, then convolve, then replace these indices
+    %         % with NaN
+    %         % 2nd option: keep NaN, use nanconv, then replace these indices
+    %         % with NaN.
+    %         % These two options will produce different results for values along
+    %         % the edges of these NaN segments
+    %
+    %     end
     
-    % principled method: If the missle values are within the temporal
-    % domain of the kernel (the length of time that the kernel spans), we
-    % will interpolate the missing values and continue with the convolution
-    % as normal. If, however, the length of the stretch of NaN values is
-    % greater than the domain of the kernel, we will assign the
-    % corresponding region of the output vector to be NaN as well.
-    
-    if strcmp(p.Results.convolveMethod, 'principled')
-        % identify any NaN values
-        NaNIndices = find(isnan(inputStruct.values(ii,:)));
-        
-        % determine the length of each NaN segment
-        
-        % interpolate over NaN segments that are short enough in duration,
-        % relative to kernel temporal domain
-        
-        % lingering question: how to handle the convolution when we will
-        % not be interpolating
-        % 1st option: interpolate, then convolve, then replace these indices
-        % with NaN
-        % 2nd option: keep NaN, use nanconv, then replace these indices
-        % with NaN.
-        % These two options will produce different results for values along
-        % the edges of these NaN segments
-        
-    end
     
     
-   
 end
 
-%% Local function nanconv
-% from matlab central, with a few modifications to force the shape of the
-% convolution be 'full', rather than 'same' which is all the built-in
-% capacity the initial function has. This was made a local function so the
-% edits to the matlab central function don't get overwritten on each
-% tbUse call
-    function c = nanconv_local(a, k, varargin)
-        % NANCONV Convolution in 1D or 2D ignoring NaNs.
-        %   C = NANCONV(A, K) convolves A and K, correcting for any NaN values
-        %   in the input vector A. The result is the same size as A (as though you
-        %   called 'conv' or 'conv2' with the 'same' shape).
-        %
-        %   C = NANCONV(A, K, 'param1', 'param2', ...) specifies one or more of the following:
-        %     'edge'     - Apply edge correction to the output.
-        %     'noedge'   - Do not apply edge correction to the output (default).
-        %     'nanout'   - The result C should have NaNs in the same places as A.
-        %     'nonanout' - The result C should have ignored NaNs removed (default).
-        %                  Even with this option, C will have NaN values where the
-        %                  number of consecutive NaNs is too large to ignore.
-        %     '2d'       - Treat the input vectors as 2D matrices (default).
-        %     '1d'       - Treat the input vectors as 1D vectors.
-        %                  This option only matters if 'a' or 'k' is a row vector,
-        %                  and the other is a column vector. Otherwise, this
-        %                  option has no effect.
-        %
-        %   NANCONV works by running 'conv2' either two or three times. The first
-        %   time is run on the original input signals A and K, except all the
-        %   NaN values in A are replaced with zeros. The 'same' input argument is
-        %   used so the output is the same size as A. The second convolution is
-        %   done between a matrix the same size as A, except with zeros wherever
-        %   there is a NaN value in A, and ones everywhere else. The output from
-        %   the first convolution is normalized by the output from the second
-        %   convolution. This corrects for missing (NaN) values in A, but it has
-        %   the side effect of correcting for edge effects due to the assumption of
-        %   zero padding during convolution. When the optional 'noedge' parameter
-        %   is included, the convolution is run a third time, this time on a matrix
-        %   of all ones the same size as A. The output from this third convolution
-        %   is used to restore the edge effects. The 'noedge' parameter is enabled
-        %   by default so that the output from 'nanconv' is identical to the output
-        %   from 'conv2' when the input argument A has no NaN values.
-        %
-        % See also conv, conv2
-        %
-        % AUTHOR: Benjamin Kraus (bkraus@bu.edu, ben@benkraus.com)
-        % Copyright (c) 2013, Benjamin Kraus
-        % $Id: nanconv.m 4861 2013-05-27 03:16:22Z bkraus $
-        
-        % Process input arguments
-
-        
-        
-        for arg = 1:nargin-2
-            switch lower(varargin{arg})
-                case 'edge'; edge = true; % Apply edge correction
-                case 'noedge'; edge = false; % Do not apply edge correction
-                case {'same','full','valid'}; shape = varargin{arg}; % Specify shape
-                case 'nanout'; nanout = true; % Include original NaNs in the output.
-                case 'nonanout'; nanout = false; % Do not include NaNs in the output.
-                case {'2d','is2d'}; is1D = false; % Treat the input as 2D
-                case {'1d','is1d'}; is1D = true; % Treat the input as 1D
-            end
-        end
-        
-        % Apply default options when necessary.
-        if(exist('edge','var')~=1); edge = false; end
-        if(exist('nanout','var')~=1); nanout = false; end
-        if(exist('is1D','var')~=1); is1D = false; end
-        if(exist('shape','var')~=1); shape = 'same';
-        elseif(~strcmp(shape,'same'))
-            error([mfilename ':NotImplemented'],'Shape ''%s'' not implemented',shape);
-        end
-        shape = 'full';
-        
-        % Get the size of 'a' for use later.
-        sza = size(a);
-        
-        % If 1D, then convert them both to columns.
-        % This modification only matters if 'a' or 'k' is a row vector, and the
-        % other is a column vector. Otherwise, this argument has no effect.
-        if(is1D);
-            if(~isvector(a) || ~isvector(k))
-                error('MATLAB:conv:AorBNotVector','A and B must be vectors.');
-            end
-            a = a(:); k = k(:);
-        end
-        
-        % Flat function for comparison.
-        o = ones(size(a));
-        
-        % Flat function with NaNs for comparison.
-        on = ones(size(a));
-        
-        % Find all the NaNs in the input.
-        n = isnan(a);
-        
-        % Replace NaNs with zero, both in 'a' and 'on'.
-        a(n) = 0;
-        on(n) = 0;
-        
-        % Check that the filter does not have NaNs.
-        if(any(isnan(k)));
-            error([mfilename ':NaNinFilter'],'Filter (k) contains NaN values.');
-        end
-        
-        % Calculate what a 'flat' function looks like after convolution.
-        if(any(n(:)) || edge)
-            flat = conv2(on,k,shape);
-            flat = flat(1:length(a));
-        else flat = o;
-        end
-        
-        % The line above will automatically include a correction for edge effects,
-        % so remove that correction if the user does not want it.
-        if(any(n(:)) && ~edge);
-            flatScaler = conv2(o,k,shape);
-            flatScaler = flatScaler(1:length(a));
-            flat = flat./flatScaler;
-        end
-        
-        % Do the actual convolution
-        c = conv2(a,k,shape);
-        c = c(1:length(a));
-        
-        makePlots = true;
-        if (makePlots)
-            plotFig = figure;
-            hold on
-            plot(c)
-            plot(flat)
-        end
-        
-        
-        
-        c = c./flat;
-        if (makePlots)
-            plot(c)
-            legend('First Convolution: NaNs set to 0', 'Second Convolution: NaNs set to 0, everyting else at 1', 'Final Output (First/Second Convolution)')
-            title('Debug nanconv')
-        end
-        
-        % If requested, replace output values with NaNs corresponding to input.
-        if(nanout); c(n) = NaN; end
-        
-        % If 1D, convert back to the original shape.
-        if(is1D && sza(1) == 1); c = c.'; end
-        
-    end
-
-
-end
 
 

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -149,7 +149,7 @@ for ii=1:nRows
 
     % Detect if nans are present in this row of values
     nanIdx = isnan(inputRow);
-    if ~isempty(nanIdx)
+    if ~isempty(find(nanIdx))
         % There are nans present. Spline interpolate over the missing
         % values
         inputRow=spline(inputStruct.timebase(~nanIdx), inputRow(~nanIdx), inputStruct.timebase);

--- a/temporalFittingEngine/@tfe/applyKernel.m
+++ b/temporalFittingEngine/@tfe/applyKernel.m
@@ -24,6 +24,14 @@ function [outputStruct,kernelStruct] = applyKernel(obj,inputStruct,kernelStruct,
 %   containing timebase and values fields.  The timebases do not need to be
 %   the same, but each must be regularly sampled.
 %
+%   The routine handles nans in the inputStruct.values vector. Spline
+%   interpolation is used to replace the nan values and convolution then
+%   proceeds as usual. If any sequential run of nan values is longer than
+%   the scalar provided by 'durationMsecsOfNansToCensor', then the output
+%   vector has a corresponding portion also set to nan, with the
+%   correspondence determined by shifting the block of nan values by the
+%   time the kernel takes to reach its absolute maximum value.
+%
 % Inputs
 %   inputStruct           - Structure with the fields timebase and values
 %   kernelStruct          - Structure with the fields timebase and values
@@ -32,7 +40,11 @@ function [outputStruct,kernelStruct] = applyKernel(obj,inputStruct,kernelStruct,
 %  'method'               - String (default 'interp1_linear').  How to
 %                           resample kernel timebase, if needed. This is
 %                           passed onto method resampleTimebase.
-%  'interp1_linear'       - Use Matlab's interp1, linear method.
+%  'durationMsecsOfNansToCensor' - Scalar. Defines the duration (in msecs)
+%                           of the length of a set of nan values in the
+%                           inputStruct.values vector that prompts the
+%                           routine to censor the corresponding portion of
+%                           the output vector.
 %
 % Outputs
 %   outputStruct          - Structure with the fields timebase and values
@@ -53,12 +65,12 @@ function [outputStruct,kernelStruct] = applyKernel(obj,inputStruct,kernelStruct,
     temporalFit = tfeIAMP('verbosity','none');
     convResponseStruct = temporalFit.applyKernel(responseStruct,kernelStruct);
     % Compare the output to a cached hash of the output
-    cachedHash = '41d0741a71e625ecc91c67f227017425';
+    cachedHash = '010d649c861c48ab4f250b788ef251d4';
     computedHash = DataHash(convResponseStruct);
     assert(strcmp(computedHash, cachedHash));
 %}
 %{
-    % A convolution containing varying amounts of NaNs
+    % Demonstrate convolution in a vector that contains nan values
     responseStruct.timebase = 0:1:25999;
     % create a sine wave responseStruct
     sinFunc = @sin;


### PR DESCRIPTION
@harrison-mcadams and @gkaguirre modified the method `applyKernel` within the `tfe` object. The routine can now handle nan values present within the values vector of the inputStruct. Spline interpolation is used to replace the nan values and convolution then proceeds as usual. If any sequential run of nan values is longer than the scalar provided by `durationMsecsOfNansToCensor`, then the output vector has a corresponding portion also set to nan, with the correspondence determined by shifting the block of nan values by the time the kernel takes to reach its absolute maximum value.

The default value of `durationMsecsOfNansToCensor` is 5000 msecs, which reflects the time-to-peak of the canonical HRF.