### PR TITLE
Support for compiled forward models

### DIFF
--- a/Models/IAMP/@tfeIAMP/computeResponse.m
+++ b/Models/IAMP/@tfeIAMP/computeResponse.m
@@ -29,11 +29,13 @@ p.addRequired('stimulusStruct',@isstruct);
 p.addRequired('kernelStruct',@(x)(isempty(x) || isstruct(x)));
 p.addParameter('errorType','rmse',@ischar);
 p.addParameter('addNoise',false,@islogical);
+p.addParameter('forwardModelHandle',@forwardModelIAMP,@(x)(isa(x,'function_handle')));
+
 p.parse(params,stimulusStruct,kernelStruct,varargin{:});
 params = p.Results.params;
 
 %% Compute the forward model
-modelResponseStruct = forwardModelIAMP(params,stimulusStruct);
+modelResponseStruct = p.Results.forwardModelHandle(params,stimulusStruct);
 
 % report an iteration has completed
 switch (obj.verbosity)

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -82,7 +82,7 @@ switch (p.Results.searchMethod)
             options = optimset(options,'DiffMinChange',p.Results.DiffMinChange);
         end
         paramsFitVec = fmincon(@(modelParamsVec)obj.fitError(modelParamsVec, ...
-            thePacket),paramsFitVec0,[],[],[],[],vlbVec,vubVec,[],options);
+            thePacket, varargin{:}),paramsFitVec0,[],[],[],[],vlbVec,vubVec,[],options);
     case 'global'
         % Slow but might work better
         opts = optimoptions(@fmincon,'Algorithm','interior-point');


### PR DESCRIPTION
The `computeResponse` method of the IAMP model has been modified to accept a key-value pair which provides a function handle to be used for the computation of the forward model. This allows the calling code base to create a MEX compiled version of the forward model, and then pass a handle to this compiled version.

To support this change, `tfe.fitResponse` was modified so that `varargin` is passed to the fmincon objective function (i.e., `fitError`). This also handles the raised issue that the key-value `errorType` was not being passed to the objective function, but only being used to calculate the final fVal.

Going forward, we will likely now want to look at moving these parameters out of the parser and into the properties of the `tfe` object at the time of instantiation.