### PR TITLE
Dbdev

### DIFF
--- a/temporalFittingEngine/@tfe/fitError.m
+++ b/temporalFittingEngine/@tfe/fitError.m
@@ -15,6 +15,9 @@ function [fVal,modelResponseStruct] = fitError(obj,paramsVec,thePacket,varargin)
 %  'errorType'         - String (default 'rmse') Type of error to compute.
 %                         'rmse' - Root mean squared error.
 %                         '1-r2' - 1-r2
+%  'errorWeightVector' - Vector of weights to use on error for each
+%                        response value. Only valid if error type is 'rmse'.
+%                        Default empty.
 %
 
 %% Parse vargin for options passed here

--- a/temporalFittingEngine/@tfe/fitError.m
+++ b/temporalFittingEngine/@tfe/fitError.m
@@ -18,6 +18,10 @@ function [fVal,modelResponseStruct] = fitError(obj,paramsVec,thePacket,varargin)
 %  'errorWeightVector' - Vector of weights to use on error for each
 %                        response value. Only valid if error type is 'rmse'.
 %                        Default empty.
+%  'fitErrorScalar'    - Computed fit error is multiplied by this before
+%                        return.  Sometimes getting the objective function
+%                        onto the right scale makes all the difference in
+%                        fitting. Default 1.
 %
 
 %% Parse vargin for options passed here
@@ -30,6 +34,7 @@ p.addRequired('paramsVec',@isnumeric);
 p.addRequired('thePacket',@isstruct);
 p.addParameter('errorType','rmse',@ischar);
 p.addParameter('errorWeightVector',[],@(x)(isempty(x) | isnumeric(x)));
+p.addParameter('fitErrorScalar',1,@isnumeric);
 p.parse(paramsVec,thePacket,varargin{:});
 
 %% If passed, perform some errorWeightVector checks
@@ -70,5 +75,8 @@ end
 if isnan(fVal)
     error('the model has returned an undefined error measurement');
 end
+
+%% Multiply by fitErrorScalar
+fVal = p.Results.fitErrorScalar*fVal;
 
 end

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -13,36 +13,76 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %
 % Optional key/value pairs
 %  'defaultParamsInfo'    - Struct (default empty).  This is passed to the
-%                           defaultParams method.
+%                           defaultParams method. This can be used to do
+%                           custom things for the search routine. [We might
+%                           try to make this go away.]
 %  'defaultParams'        - Struct (default empty). Params values for
 %                           defaultParams to return. In turn determines
-%                           starting value for search.
+%                           starting value for search, unless overridden by
+%                           a non-empty initialParams key/value pair. [We
+%                           might try to make this go away, and use the
+%                           initialParams key/value pair below, which is
+%                           simpler to read and think about.]
+%  'intialParams'         - Struct (default empty). Params structure
+%                           containing initial parameters for search. If empty,
+%                           what's returned by the defaultParams method is
+%                           used. This key/value pair overrides the
+%                           defaultParams key/value pair, which in turn
+%                           overrides what is returned by the
+%                           defaultParams method.
+%  'vlbParams'            - Struct (default empty). Params structure
+%                           containing lower bounds for search. If empty,
+%                           what's returned by the defaultParams method is
+%                           used.
+%  'vubParams'            - Struct (default empty). Params structure
+%                           containing upper bounds for search. If empty,
+%                           what's returned by the defaultParams method is
+%                           used.
+%  'A'                     - Matrix (default empty). Linear inequality
+%                           constraint matrix.
+%  'b'                    - Vector (default empty). Linear inequality
+%                           constraint vector.
+%  'Aeq'                  - Matrix (default empty). Linear equality
+%                           constraint matrix.
+%  'beq'                  - Vector (default empty). Linear equality
+%                           constraint vector.
 %  'searchMethod          - String (default 'fmincon').  Specify search
 %                           method:
 %                              'fmincon' - Use fmincon
-%                              'global' - Use global search
-%                              'linearRegression' - rapid estimation of
+%                              'linearRegression' - Rapid estimation of
 %                                   simplified models with only an
-%                                   amplitude parameter
+%                                   amplitude parameter. Parameter bounds
+%                                   and constraints do not apply. Nor does
+%                                   errorType or errorWeightVector.
 %  'DiffMinChange'        - Double (default empty). If not empty, changes
 %                           the default value of this in the fmincon
 %                           optionset.
 %  'fminconAlgorithm'     - String (default 'active-set'). Passed on as
 %                           algorithm in options to fmincon.
-%  'errorType'            - String (default 'rmse'). Determines what error 
-%                           is minimized, passed as an option to fitError
-%                           method.
+%  'errorType'            - String (default 'rmse'). Determines what error
+%                           is minimized, passed along as an option to the
+%                           fitError method.
+%  'errorWeightVector'    - Vector of weights to use on error for each
+%                           response value. Only valid if error type is
+%                           'rmse'. Default empty. Passed along as an
+%                           option to the fitError method.
 %
 % Outputs:
 %   paramsFit             - Structure. Fit parameters.
 %   fVal                  - Scalar. Fit error
 %   predictedResponse     - Structure. Response predicted from fit.
-%
+
 % History:
-%   11/26/18  dhb       Added comments about key/value pairs that were not
-%                       previously commented.
-%   12/09/18  dhb       Comment improvements.
-%   12/13/18  gka       Notes placed in git commit comments.
+%  11/26/18  dhb       Added comments about key/value pairs that were not
+%                      previously commented.
+%  12/09/18  dhb       Comment improvements.
+%  12/13/18  gka       Notes placed in git commit comments.
+%  01/01/18  dhb       Allows explicit passing of initial parameters,
+%                      bounds, and search constraints.
+%            dhb       Code cleaning. Remove comment about 'global'
+%                      searchMethod value, because it doesn't exist in the code.
+%           dhb        Final computation of error was not using
+%                      errorWeightVector.  Now passed on.
 
 %% Parse vargin for options passed here
 %
@@ -53,6 +93,13 @@ p = inputParser; p.KeepUnmatched = true; p.PartialMatching = false;
 p.addRequired('thePacket',@isstruct);
 p.addParameter('defaultParamsInfo',[],@(x)(isempty(x) | isstruct(x)));
 p.addParameter('defaultParams',[],@(x)(isempty(x) | isstruct(x)));
+p.addParameter('initialParams',[],@(x)(isempty(x) | isstruct(x)));
+p.addParameter('vlbParams',[],@(x)(isempty(x) | isstruct(x)));
+p.addParameter('vubParams',[],@(x)(isempty(x) | isstruct(x)));
+p.addParameter('A',[],@isnumeric);
+p.addParameter('b',[],@isnumeric);
+p.addParameter('Aeq',[],@isnumeric);
+p.addParameter('beq',[],@isnumeric);
 p.addParameter('searchMethod','fmincon',@ischar);
 p.addParameter('DiffMinChange',[],@isnumeric);
 p.addParameter('fminconAlgorithm','active-set',@ischar);
@@ -70,10 +117,24 @@ else
 end
 
 %% Set initial values and reasonable bounds on parameters
-[paramsFit0,vlb,vub] = obj.defaultParams('defaultParamsInfo',p.Results.defaultParamsInfo,'defaultParams',p.Results.defaultParams,varargin{:});
-paramsFitVec0 = obj.paramsToVec(paramsFit0);
-vlbVec = obj.paramsToVec(vlb);
-vubVec = obj.paramsToVec(vub);
+% Uses defaultParams method.
+[initialParams,vlbParams,vubParams] = obj.defaultParams('defaultParamsInfo',p.Results.defaultParamsInfo,'defaultParams',p.Results.defaultParams,varargin{:});
+
+%% Optional override of initial params and bounds
+if (~isempty(p.Results.initialParams))
+    initialParams = p.Results.initialParams;
+end
+if (~isempty(p.Results.vlbParams))
+    initialParams = p.Results.vlbParams;
+end
+if (~isempty(p.Results.vubParams))
+    initialParams = p.Results.vubParams;
+end
+
+%% Convert initial params and bounds to vector form
+initialParamsVec = obj.paramsToVec(initialParams);
+vlbVec = obj.paramsToVec(vlbParams);
+vubVec = obj.paramsToVec(vubParams);
 
 %% David sez: "Fit that sucker"
 switch (obj.verbosity)
@@ -88,34 +149,42 @@ switch (p.Results.searchMethod)
         if ~isempty(p.Results.DiffMinChange)
             options = optimset(options,'DiffMinChange',p.Results.DiffMinChange);
         end
-        paramsFitVec = fmincon(@(modelParamsVec)obj.fitError(modelParamsVec, ...
-            thePacket, varargin{:}),paramsFitVec0,[],[],[],[],vlbVec,vubVec,[],options);
+        paramsFitVec = fmincon(@(modelParamsVec)obj.fitError(modelParamsVec,thePacket,varargin{:}), ...
+            initialParamsVec,p.Results.A,p.Results.b,p.Results.Aeq,p.Results.beq,vlbVec,vubVec,[],options);
+    
     case 'linearRegression'
-        % linear regression can be used only when the paramsFit0 has only
-        % a single parameter.
-        if length(paramsFit0.paramNameCell)~=1
+        % Linear regression can be used only when the paramsFit0 has only a
+        % single parameter.  In addition, constraints,bounds,errorType and
+        % errorWeightVector do not apply to this method.
+        if length(initialParams.paramNameCell)~=1
             error('fitResponse:invalidLinearRegression','Linear regression can only be applied in the case of a single model parameter')
         end
+        
         %  Warn if the parameter is not called "amplitude".
-        if ~(min(paramsFit0.paramNameCell{1}=='amplitude')==1)
+        if ~(min(initialParams.paramNameCell{1}=='amplitude')==1)
             warning('fitResponse:invalidLinearRegression','Only amplitude parameters are suitable for linear regression')
         end
+        
         % Take the stimulus.values as the regression matrix
         regressionMatrixStruct=thePacket.stimulus;
+        
         % Convolve the rows of stimulus values by the kernel
         regressionMatrixStruct = obj.applyKernel(regressionMatrixStruct,thePacket.kernel,varargin{:});
+        
         % Downsample regressionMatrixStruct to the timebase of the response
         regressionMatrixStruct = obj.resampleTimebase(regressionMatrixStruct,thePacket.response.timebase,varargin{:});
+        
         % Perform the regression
         X=regressionMatrixStruct.values';
         y=thePacket.response.values';
         paramsFitVec=X\y;
+        
     otherwise
         error('fitResponse:invalidSearchMethod','Do not know how to fit that sucker with specified method');
 end
 
 % Get error and predicted response for final parameters
-[fVal,modelResponseStruct] = obj.fitError(paramsFitVec,thePacket,'errorType',p.Results.errorType);
+[fVal,modelResponseStruct] = obj.fitError(paramsFitVec,thePacket,varargin{:});
 
 switch (obj.verbosity)
     case 'high'

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -64,7 +64,12 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %                           fitError method.
 %  'errorWeightVector'    - Vector of weights to use on error for each
 %                           response value. Only valid if error type is
-%                           'rmse'. Default empty. Passed along as an
+%                           'rmse'. Passed along as an option to the
+%                           fitError method.
+%  'fitErrorScalar'       - Computed fit error is multiplied by this before
+%                           return.  Sometimes getting the objective
+%                           function onto the right scale makes all the
+%                           difference in fitting. Passed along as an
 %                           option to the fitError method.
 %
 % Outputs:
@@ -103,7 +108,6 @@ p.addParameter('beq',[],@isnumeric);
 p.addParameter('searchMethod','fmincon',@ischar);
 p.addParameter('DiffMinChange',[],@isnumeric);
 p.addParameter('fminconAlgorithm','active-set',@ischar);
-p.addParameter('errorType','rmse',@ischar);
 p.parse(thePacket,varargin{:});
 
 % Check packet validity

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -129,10 +129,10 @@ if (~isempty(p.Results.initialParams))
     initialParams = p.Results.initialParams;
 end
 if (~isempty(p.Results.vlbParams))
-    initialParams = p.Results.vlbParams;
+    vlbParams = p.Results.vlbParams;
 end
 if (~isempty(p.Results.vubParams))
-    initialParams = p.Results.vubParams;
+    vubParams = p.Results.vubParams;
 end
 
 %% Convert initial params and bounds to vector form

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -57,11 +57,13 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %  'DiffMinChange'        - Double (default empty). If not empty, changes
 %                           the default value of this in the fmincon
 %                           optionset.
-%  'fminconAlgorithm'     - String (default empty). If set to a string,
+%  'fminconAlgorithm'     - String (default 'active-set'). If set to a string,
 %                           passed on as algorithm in options to fmincon.
-%                           Leaving empty gets fmincon's default algorithm.
-%                           For some cases, using 'active-set' here may be
-%                           a good idea.
+%                           Can be empty or any algorithm string understood
+%                           by fmincon.
+%                              [] - Use fmincon's current default algorithm
+%                              'active-set' - Active set algorithm
+%                              'interior-point' - Interior point algorithm.
 %  'errorType'            - String (default 'rmse'). Determines what error
 %                           is minimized, passed along as an option to the
 %                           fitError method.
@@ -89,10 +91,8 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %                      bounds, and search constraints.
 %            dhb       Code cleaning. Remove comment about 'global'
 %                      searchMethod value, because it doesn't exist in the code.
-%           dhb        Final computation of error was not using
+%            dhb       Final computation of error was not using
 %                      errorWeightVector.  Now passed on.
-%          dhb         Use default fmincon algorithm, rather than
-%                      defaulting to 'active-set'
 
 %% Parse vargin for options passed here
 %
@@ -112,7 +112,7 @@ p.addParameter('Aeq',[],@isnumeric);
 p.addParameter('beq',[],@isnumeric);
 p.addParameter('searchMethod','fmincon',@ischar);
 p.addParameter('DiffMinChange',[],@isnumeric);
-p.addParameter('fminconAlgorithm',[]',@(x) (isempty(x) | ischar(x)));
+p.addParameter('fminconAlgorithm','active-set',@(x) (isempty(x) | ischar(x)));
 p.parse(thePacket,varargin{:});
 
 % Check packet validity
@@ -156,7 +156,7 @@ switch (p.Results.searchMethod)
         options = optimset('fmincon');
         options = optimset(options,'Diagnostics','off','Display','off','LargeScale','off');
         if (~isempty(p.Results.fminconAlgorithm))
-            options = optimset(options,'fminconAlgorithm',p.Results.fminconAlgorithm);
+            options = optimset(options,'Algorithm',p.Results.fminconAlgorithm);
         end
         if ~isempty(p.Results.DiffMinChange)
             options = optimset(options,'DiffMinChange',p.Results.DiffMinChange);

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -57,8 +57,9 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %  'DiffMinChange'        - Double (default empty). If not empty, changes
 %                           the default value of this in the fmincon
 %                           optionset.
-%  'fminconAlgorithm'     - String (default 'active-set'). Passed on as
-%                           algorithm in options to fmincon.
+%  'fminconAlgorithm'     - String (default empty). If set to a string,
+%                           passed on as algorithm in options to fmincon.
+%                           Leaving empty gets fmincon's default algorithm.
 %  'errorType'            - String (default 'rmse'). Determines what error
 %                           is minimized, passed along as an option to the
 %                           fitError method.
@@ -88,6 +89,8 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %                      searchMethod value, because it doesn't exist in the code.
 %           dhb        Final computation of error was not using
 %                      errorWeightVector.  Now passed on.
+%          dhb         Use default fmincon algorithm, rather than
+%                      defaulting to 'active-set'
 
 %% Parse vargin for options passed here
 %
@@ -107,7 +110,7 @@ p.addParameter('Aeq',[],@isnumeric);
 p.addParameter('beq',[],@isnumeric);
 p.addParameter('searchMethod','fmincon',@ischar);
 p.addParameter('DiffMinChange',[],@isnumeric);
-p.addParameter('fminconAlgorithm','active-set',@ischar);
+p.addParameter('fminconAlgorithm',[]',@(x) (isempty(x) | ischar(x)));
 p.parse(thePacket,varargin{:});
 
 % Check packet validity
@@ -149,7 +152,10 @@ end
 switch (p.Results.searchMethod)
     case 'fmincon'
         options = optimset('fmincon');
-        options = optimset(options,'Diagnostics','off','Display','off','LargeScale','off','Algorithm',p.Results.fminconAlgorithm);
+        options = optimset(options,'Diagnostics','off','Display','off','LargeScale','off');
+        if (~isempty(p.Results.fminconAlgorithm))
+            options = optimset(options,'fminconAlgorithm',p.Results.fminconAlgorithm);
+        end
         if ~isempty(p.Results.DiffMinChange)
             options = optimset(options,'DiffMinChange',p.Results.DiffMinChange);
         end

--- a/temporalFittingEngine/@tfe/fitResponse.m
+++ b/temporalFittingEngine/@tfe/fitResponse.m
@@ -60,6 +60,8 @@ function [paramsFit,fVal,modelResponseStruct] = fitResponse(obj,thePacket,vararg
 %  'fminconAlgorithm'     - String (default empty). If set to a string,
 %                           passed on as algorithm in options to fmincon.
 %                           Leaving empty gets fmincon's default algorithm.
+%                           For some cases, using 'active-set' here may be
+%                           a good idea.
 %  'errorType'            - String (default 'rmse'). Determines what error
 %                           is minimized, passed along as an option to the
 %                           fitError method.


### PR DESCRIPTION
Main change is to add a bunch of key-value pairs to fitResponse. These allow passing of search bounds and constraints, which makes it easier to resuse tfe.fitResponse from custom fitResponse methods in subclasses.

Also added an option to pass a scalar (default 1) to the fitError method and pass this down from fitResponse. This allows tuning of the overall magnitude of the error function, which I sometimes find is needed to get searches to converge well.

Added an 'initialParams' key/value pair which overrides what is returned by defaultParams if set non-empty. I think writing with this is clearer than using the 'defaultParams' key/value pair, which modifies what is returned by the defaultParams method. The 'defaultParams' key/value pair is still there and works the way it did.  If you pass something for both 'initialParams' and 'defaultParams', I am pretty sure that the 'initialParams' value wins.

All validations pass on this branch, and all tutorials still run.